### PR TITLE
Arreglo error, que pausa cancion al hacer clic en lista

### DIFF
--- a/app/vista.py
+++ b/app/vista.py
@@ -86,7 +86,6 @@ class VistaPrincipal(QtWidgets.QMainWindow):
         self.buscar.emit()
 
     def on_clicked_lista(self):
-        self.__cambiar_boton()
         self.__id_cancion_actual = True
 
     def on_clicked_reproducir(self):


### PR DESCRIPTION
En este hotfix se repara el error que pausa la canción al hacer clic en la lista